### PR TITLE
ros2: guard reset target trajectories and install auto_generated configs

### DIFF
--- a/ocs2_robotic_examples/ocs2_mobile_manipulator/CMakeLists.txt
+++ b/ocs2_robotic_examples/ocs2_mobile_manipulator/CMakeLists.txt
@@ -78,6 +78,9 @@ install(DIRECTORY include/${PROJECT_NAME}/
 install(DIRECTORY config
   DESTINATION share/${PROJECT_NAME}
 )
+install(DIRECTORY auto_generated
+  DESTINATION share/${PROJECT_NAME}
+)
 
 install(
   EXPORT export_${PROJECT_NAME}

--- a/ocs2_ros_interfaces/src/common/RosMsgConversions.cpp
+++ b/ocs2_ros_interfaces/src/common/RosMsgConversions.cpp
@@ -230,9 +230,9 @@ TargetTrajectories readTargetTrajectoriesMsg(
   vector_array_t desiredStateTrajectory(N);
   for (size_t i = 0; i < N; i++) {
     desiredTimeTrajectory[i] = targetTrajectoriesMsg.time_trajectory[i];
-    if (i > 0 && !(desiredTimeTrajectory[i - 1] < desiredTimeTrajectory[i])) {
+    if (i > 0 && desiredTimeTrajectory[i] < desiredTimeTrajectory[i - 1]) {
       throw std::runtime_error(
-          "Target trajectories message has non-increasing time trajectory.");
+          "Target trajectories message has decreasing time trajectory.");
     }
 
     desiredStateTrajectory[i] =

--- a/ocs2_ros_interfaces/src/common/RosMsgConversions.cpp
+++ b/ocs2_ros_interfaces/src/common/RosMsgConversions.cpp
@@ -208,17 +208,32 @@ ocs2_msgs::msg::MpcTargetTrajectories createTargetTrajectoriesMsg(
 /******************************************************************************************************/
 TargetTrajectories readTargetTrajectoriesMsg(
     const ocs2_msgs::msg::MpcTargetTrajectories& targetTrajectoriesMsg) {
-  size_t N = targetTrajectoriesMsg.state_trajectory.size();
-  if (N == 0) {
+  const size_t stateTrajectorySize = targetTrajectoriesMsg.state_trajectory.size();
+  const size_t timeTrajectorySize = targetTrajectoriesMsg.time_trajectory.size();
+  const size_t inputTrajectorySize = targetTrajectoriesMsg.input_trajectory.size();
+  if (stateTrajectorySize == 0) {
     throw std::runtime_error(
         "An empty target trajectories message is received.");
   }
+  if (timeTrajectorySize != stateTrajectorySize) {
+    throw std::runtime_error(
+        "Target trajectories message has mismatched time/state trajectory lengths.");
+  }
+  if (inputTrajectorySize != 0 && inputTrajectorySize != stateTrajectorySize) {
+    throw std::runtime_error(
+        "Target trajectories message has mismatched input/state trajectory lengths.");
+  }
 
   // state and time
+  const size_t N = stateTrajectorySize;
   scalar_array_t desiredTimeTrajectory(N);
   vector_array_t desiredStateTrajectory(N);
   for (size_t i = 0; i < N; i++) {
     desiredTimeTrajectory[i] = targetTrajectoriesMsg.time_trajectory[i];
+    if (i > 0 && !(desiredTimeTrajectory[i - 1] < desiredTimeTrajectory[i])) {
+      throw std::runtime_error(
+          "Target trajectories message has non-increasing time trajectory.");
+    }
 
     desiredStateTrajectory[i] =
         Eigen::Map<const Eigen::VectorXf>(
@@ -228,9 +243,8 @@ TargetTrajectories readTargetTrajectoriesMsg(
   }  // end of i loop
 
   // input
-  N = targetTrajectoriesMsg.input_trajectory.size();
-  vector_array_t desiredInputTrajectory(N);
-  for (size_t i = 0; i < N; i++) {
+  vector_array_t desiredInputTrajectory(inputTrajectorySize);
+  for (size_t i = 0; i < inputTrajectorySize; i++) {
     desiredInputTrajectory[i] =
         Eigen::Map<const Eigen::VectorXf>(
             targetTrajectoriesMsg.input_trajectory[i].value.data(),

--- a/ocs2_ros_interfaces/src/mpc/MPC_ROS_Interface.cpp
+++ b/ocs2_ros_interfaces/src/mpc/MPC_ROS_Interface.cpp
@@ -32,10 +32,105 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "ocs2_ros_interfaces/common/RosMsgConversions.h"
 
 #include <stdexcept>
+#include <sstream>
 
 const rclcpp::Logger LOGGER = rclcpp::get_logger("MPC_ROS_Interface");
 
 namespace ocs2 {
+namespace {
+
+size_t inferDimFromTrajectory(const vector_array_t& trajectory) {
+  for (const auto& sample : trajectory) {
+    if (sample.size() > 0) {
+      return sample.size();
+    }
+  }
+  return 0;
+}
+
+[[noreturn]] void throwTargetTrajectoriesError(const std::string& message) {
+  throw std::runtime_error(
+      std::string("[MPC_ROS_Interface] Invalid reset target trajectories: ") +
+      message);
+}
+
+void validateResetTargetTrajectories(
+    const TargetTrajectories& targetTrajectories,
+    const TargetTrajectories& referenceTrajectories) {
+  const auto N = targetTrajectories.timeTrajectory.size();
+  if (N == 0) {
+    throwTargetTrajectoriesError("timeTrajectory is empty.");
+  }
+  if (targetTrajectories.stateTrajectory.size() != N) {
+    throwTargetTrajectoriesError("stateTrajectory length does not match timeTrajectory.");
+  }
+  if (!targetTrajectories.inputTrajectory.empty() &&
+      targetTrajectories.inputTrajectory.size() != N) {
+    throwTargetTrajectoriesError("inputTrajectory length does not match timeTrajectory.");
+  }
+
+  for (size_t i = 1; i < N; i++) {
+    if (!(targetTrajectories.timeTrajectory[i - 1] <
+          targetTrajectories.timeTrajectory[i])) {
+      std::ostringstream stream;
+      stream << "timeTrajectory must be strictly increasing, but t[" << i - 1
+             << "]=" << targetTrajectories.timeTrajectory[i - 1] << " and t["
+             << i << "]=" << targetTrajectories.timeTrajectory[i] << ".";
+      throwTargetTrajectoriesError(stream.str());
+    }
+  }
+
+  const auto stateDim = targetTrajectories.stateTrajectory.front().size();
+  for (size_t i = 0; i < N; i++) {
+    const auto sampleDim = targetTrajectories.stateTrajectory[i].size();
+    if (sampleDim != stateDim) {
+      std::ostringstream stream;
+      stream << "stateTrajectory dimension mismatch at index " << i
+             << ": expected " << stateDim << ", got " << sampleDim << ".";
+      throwTargetTrajectoriesError(stream.str());
+    }
+  }
+
+  size_t inputDim = 0;
+  if (!targetTrajectories.inputTrajectory.empty()) {
+    inputDim = targetTrajectories.inputTrajectory.front().size();
+    for (size_t i = 0; i < N; i++) {
+      const auto sampleDim = targetTrajectories.inputTrajectory[i].size();
+      if (sampleDim != inputDim) {
+        std::ostringstream stream;
+        stream << "inputTrajectory dimension mismatch at index " << i
+               << ": expected " << inputDim << ", got " << sampleDim << ".";
+        throwTargetTrajectoriesError(stream.str());
+      }
+    }
+  }
+
+  const auto expectedStateDim = inferDimFromTrajectory(referenceTrajectories.stateTrajectory);
+  if (expectedStateDim > 0 && stateDim != expectedStateDim) {
+    std::ostringstream stream;
+    stream << "stateTrajectory dimension mismatch vs active reference: expected "
+           << expectedStateDim << ", got " << stateDim << ".";
+    throwTargetTrajectoriesError(stream.str());
+  }
+
+  const auto expectedInputDim = inferDimFromTrajectory(referenceTrajectories.inputTrajectory);
+  if (expectedInputDim > 0) {
+    if (targetTrajectories.inputTrajectory.empty()) {
+      std::ostringstream stream;
+      stream << "inputTrajectory is empty but active reference expects dimension "
+             << expectedInputDim << ".";
+      throwTargetTrajectoriesError(stream.str());
+    }
+    if (inputDim != expectedInputDim) {
+      std::ostringstream stream;
+      stream << "inputTrajectory dimension mismatch vs active reference: expected "
+             << expectedInputDim << ", got " << inputDim << ".";
+      throwTargetTrajectoriesError(stream.str());
+    }
+  }
+}
+
+}  // namespace
 
 /******************************************************************************************************/
 /******************************************************************************************************/
@@ -82,16 +177,27 @@ void MPC_ROS_Interface::resetMpcCallback(
     const std::shared_ptr<ocs2_msgs::srv::Reset::Request> req,
     std::shared_ptr<ocs2_msgs::srv::Reset::Response> res) {
   if (req->reset) {
-    auto targetTrajectories = ros_msg_conversions::readTargetTrajectoriesMsg(
-        req->target_trajectories);
-    resetMpcNode(std::move(targetTrajectories));
-    res->done = true;
+    try {
+      auto targetTrajectories = ros_msg_conversions::readTargetTrajectoriesMsg(
+          req->target_trajectories);
+      const auto& referenceTrajectories =
+          mpc_.getSolverPtr()->getReferenceManager().getTargetTrajectories();
+      validateResetTargetTrajectories(targetTrajectories, referenceTrajectories);
 
-    std::cerr << "\n#####################################################"
-              << "\n#####################################################"
-              << "\n#################  MPC is reset.  ###################"
-              << "\n#####################################################"
-              << "\n#####################################################\n";
+      resetMpcNode(std::move(targetTrajectories));
+      res->done = true;
+
+      std::cerr << "\n#####################################################"
+                << "\n#####################################################"
+                << "\n#################  MPC is reset.  ###################"
+                << "\n#####################################################"
+                << "\n#####################################################\n";
+    } catch (const std::exception& e) {
+      res->done = false;
+      RCLCPP_ERROR_STREAM(LOGGER,
+                          "[MPC_ROS_Interface] Reset request failed: "
+                              << e.what());
+    }
   } else {
     res->done = false;
     RCLCPP_WARN_STREAM(LOGGER, "[MPC_ROS_Interface] Reset request failed!");

--- a/ocs2_ros_interfaces/src/mpc/MPC_ROS_Interface.cpp
+++ b/ocs2_ros_interfaces/src/mpc/MPC_ROS_Interface.cpp
@@ -39,13 +39,10 @@ const rclcpp::Logger LOGGER = rclcpp::get_logger("MPC_ROS_Interface");
 namespace ocs2 {
 namespace {
 
-size_t inferDimFromTrajectory(const vector_array_t& trajectory) {
-  for (const auto& sample : trajectory) {
-    if (sample.size() > 0) {
-      return sample.size();
-    }
-  }
-  return 0;
+size_t inferDimFromTrajectory(const vector_array_t& trajectory,
+                              bool& hasSamples) {
+  hasSamples = !trajectory.empty();
+  return hasSamples ? trajectory.front().size() : 0;
 }
 
 [[noreturn]] void throwTargetTrajectoriesError(const std::string& message) {
@@ -70,10 +67,10 @@ void validateResetTargetTrajectories(
   }
 
   for (size_t i = 1; i < N; i++) {
-    if (!(targetTrajectories.timeTrajectory[i - 1] <
-          targetTrajectories.timeTrajectory[i])) {
+    if (targetTrajectories.timeTrajectory[i] <
+        targetTrajectories.timeTrajectory[i - 1]) {
       std::ostringstream stream;
-      stream << "timeTrajectory must be strictly increasing, but t[" << i - 1
+      stream << "timeTrajectory must be non-decreasing, but t[" << i - 1
              << "]=" << targetTrajectories.timeTrajectory[i - 1] << " and t["
              << i << "]=" << targetTrajectories.timeTrajectory[i] << ".";
       throwTargetTrajectoriesError(stream.str());
@@ -105,27 +102,44 @@ void validateResetTargetTrajectories(
     }
   }
 
-  const auto expectedStateDim = inferDimFromTrajectory(referenceTrajectories.stateTrajectory);
-  if (expectedStateDim > 0 && stateDim != expectedStateDim) {
+  bool hasReferenceState = false;
+  const auto expectedStateDim =
+      inferDimFromTrajectory(referenceTrajectories.stateTrajectory,
+                            hasReferenceState);
+  if (hasReferenceState && stateDim != expectedStateDim) {
     std::ostringstream stream;
     stream << "stateTrajectory dimension mismatch vs active reference: expected "
            << expectedStateDim << ", got " << stateDim << ".";
     throwTargetTrajectoriesError(stream.str());
   }
 
-  const auto expectedInputDim = inferDimFromTrajectory(referenceTrajectories.inputTrajectory);
-  if (expectedInputDim > 0) {
-    if (targetTrajectories.inputTrajectory.empty()) {
-      std::ostringstream stream;
-      stream << "inputTrajectory is empty but active reference expects dimension "
-             << expectedInputDim << ".";
-      throwTargetTrajectoriesError(stream.str());
-    }
-    if (inputDim != expectedInputDim) {
-      std::ostringstream stream;
-      stream << "inputTrajectory dimension mismatch vs active reference: expected "
-             << expectedInputDim << ", got " << inputDim << ".";
-      throwTargetTrajectoriesError(stream.str());
+  bool hasReferenceInput = false;
+  const auto expectedInputDim =
+      inferDimFromTrajectory(referenceTrajectories.inputTrajectory,
+                            hasReferenceInput);
+  if (hasReferenceInput && !targetTrajectories.inputTrajectory.empty() &&
+      inputDim != expectedInputDim) {
+    std::ostringstream stream;
+    stream << "inputTrajectory dimension mismatch vs active reference: expected "
+           << expectedInputDim << ", got " << inputDim << ".";
+    throwTargetTrajectoriesError(stream.str());
+  }
+  if (hasReferenceInput && targetTrajectories.inputTrajectory.empty() &&
+      expectedInputDim > 0) {
+    std::ostringstream stream;
+    stream << "inputTrajectory is empty but active reference expects dimension "
+           << expectedInputDim << ".";
+    throwTargetTrajectoriesError(stream.str());
+  }
+  if (hasReferenceInput && expectedInputDim == 0 &&
+      !targetTrajectories.inputTrajectory.empty()) {
+    for (size_t i = 0; i < N; i++) {
+      if (targetTrajectories.inputTrajectory[i].size() != 0) {
+        std::ostringstream stream;
+        stream << "inputTrajectory must be zero-dimension at index " << i
+               << " to match active reference.";
+        throwTargetTrajectoriesError(stream.str());
+      }
     }
   }
 }

--- a/ocs2_ros_interfaces/src/mrt/MRT_ROS_Interface.cpp
+++ b/ocs2_ros_interfaces/src/mrt/MRT_ROS_Interface.cpp
@@ -249,14 +249,21 @@ void MRT_ROS_Interface::readPolicyMsg(
 /******************************************************************************************************/
 void MRT_ROS_Interface::mpcPolicyCallback(
     const ocs2_msgs::msg::MpcFlattenedController::ConstSharedPtr& msg) {
-  // read new policy and command from msg
-  auto commandPtr = std::make_unique<CommandData>();
-  auto primalSolutionPtr = std::make_unique<PrimalSolution>();
-  auto performanceIndicesPtr = std::make_unique<PerformanceIndex>();
-  readPolicyMsg(*msg, *commandPtr, *primalSolutionPtr, *performanceIndicesPtr);
+  try {
+    // read new policy and command from msg
+    auto commandPtr = std::make_unique<CommandData>();
+    auto primalSolutionPtr = std::make_unique<PrimalSolution>();
+    auto performanceIndicesPtr = std::make_unique<PerformanceIndex>();
+    readPolicyMsg(*msg, *commandPtr, *primalSolutionPtr,
+                  *performanceIndicesPtr);
 
-  this->moveToBuffer(std::move(commandPtr), std::move(primalSolutionPtr),
-                     std::move(performanceIndicesPtr));
+    this->moveToBuffer(std::move(commandPtr), std::move(primalSolutionPtr),
+                       std::move(performanceIndicesPtr));
+  } catch (const std::exception& e) {
+    RCLCPP_ERROR_STREAM(LOGGER,
+                        "[MRT_ROS_Interface] Dropping invalid policy message: "
+                            << e.what());
+  }
 }
 
 /******************************************************************************************************/

--- a/ocs2_ros_interfaces/src/synchronized_module/RosReferenceManager.cpp
+++ b/ocs2_ros_interfaces/src/synchronized_module/RosReferenceManager.cpp
@@ -54,8 +54,14 @@ void RosReferenceManager::subscribe(const rclcpp::Node::SharedPtr& node) {
   node_ = node;
   // ModeSchedule
   auto modeScheduleCallback = [this](const ocs2_msgs::msg::ModeSchedule& msg) {
-    auto modeSchedule = ros_msg_conversions::readModeScheduleMsg(msg);
-    referenceManagerPtr_->setModeSchedule(std::move(modeSchedule));
+    try {
+      auto modeSchedule = ros_msg_conversions::readModeScheduleMsg(msg);
+      referenceManagerPtr_->setModeSchedule(std::move(modeSchedule));
+    } catch (const std::exception& e) {
+      RCLCPP_ERROR_STREAM(node_->get_logger(),
+                          "[RosReferenceManager] Dropping invalid mode schedule: "
+                              << e.what());
+    }
   };
   modeScheduleSubscriber_ =
       node_->create_subscription<ocs2_msgs::msg::ModeSchedule>(
@@ -64,10 +70,16 @@ void RosReferenceManager::subscribe(const rclcpp::Node::SharedPtr& node) {
   // TargetTrajectories
   auto targetTrajectoriesCallback =
       [this](const ocs2_msgs::msg::MpcTargetTrajectories& msg) {
-        auto targetTrajectories =
-            ros_msg_conversions::readTargetTrajectoriesMsg(msg);
-        referenceManagerPtr_->setTargetTrajectories(
-            std::move(targetTrajectories));
+        try {
+          auto targetTrajectories =
+              ros_msg_conversions::readTargetTrajectoriesMsg(msg);
+          referenceManagerPtr_->setTargetTrajectories(
+              std::move(targetTrajectories));
+        } catch (const std::exception& e) {
+          RCLCPP_ERROR_STREAM(node_->get_logger(),
+                              "[RosReferenceManager] Dropping invalid target trajectories: "
+                                  << e.what());
+        }
       };
   targetTrajectoriesSubscriber_ =
       node_->create_subscription<ocs2_msgs::msg::MpcTargetTrajectories>(


### PR DESCRIPTION
## Summary
- install `auto_generated/` assets for `ocs2_mobile_manipulator` so generated task/model files are present under `share/` after install
- harden `readTargetTrajectoriesMsg()` with structural checks (time/state/input length consistency + non-decreasing time)
- validate reset target trajectory dimensions against active reference dimensions in `MPC_ROS_Interface::resetMpcCallback()` (including `nu=0` cases) and fail reset requests gracefully instead of aborting
- catch malformed target/policy messages in ROS subscribers (`RosReferenceManager`, `MRT_ROS_Interface`) and drop them with explicit error logs

## Why
On robot bring-up, malformed target/reset payloads can flow into MPC and trigger downstream Eigen assertions or uncaught callback exceptions, terminating processes. This change rejects or drops malformed payloads early with explicit diagnostics.

## Validation
- `colcon build --symlink-install --packages-select ocs2_ros_interfaces mole_ocs2_mobile_manipulator_ros mole_ocs2_arm_controller`
- independent PR review agent run on this branch after updates: no remaining medium/high findings; one low residual risk (no dedicated tests yet for new malformed-message paths)