### PR TITLE
ros2: harden SCHED_FIFO thread-priority setup

### DIFF
--- a/ocs2_core/include/ocs2_core/thread_support/SetThreadPriority.h
+++ b/ocs2_core/include/ocs2_core/thread_support/SetThreadPriority.h
@@ -29,6 +29,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #pragma once
 
+#include <algorithm>
+#include <cstring>
+#include <sched.h>
 #include <pthread.h>
 #include <iostream>
 #include <thread>
@@ -42,15 +45,26 @@ namespace ocs2 {
  * @param thread: A reference to the tread.
  */
 inline void setThreadPriority(int priority, pthread_t thread) {
-  sched_param sched{};
-  sched.sched_priority = priority;
+  if (priority == 0) {
+    return;
+  }
 
-  if (priority != 0) {
-    if (pthread_setschedparam(thread, SCHED_FIFO, &sched) != 0) {
-      std::cerr << "WARNING: Failed to set threads priority (one possible reason could be "
-                   "that the user and the group permissions are not set properly.)"
-                << std::endl;
-    }
+  const int minPriority = sched_get_priority_min(SCHED_FIFO);
+  const int maxPriority = sched_get_priority_max(SCHED_FIFO);
+  const int boundedPriority = std::min(std::max(priority, minPriority), maxPriority);
+  if (boundedPriority != priority) {
+    std::cerr << "WARNING: Requested thread priority " << priority << " is outside SCHED_FIFO bounds ["
+              << minPriority << ", " << maxPriority << "], clamping to " << boundedPriority << "." << std::endl;
+  }
+
+  sched_param sched{};
+  sched.sched_priority = boundedPriority;
+
+  const int rc = pthread_setschedparam(thread, SCHED_FIFO, &sched);
+  if (rc != 0) {
+    std::cerr << "WARNING: Failed to set thread priority to " << boundedPriority
+              << " with SCHED_FIFO (pthread_setschedparam rc=" << rc << ": " << std::strerror(rc)
+              << "). Check realtime permissions (e.g., RLIMIT_RTPRIO and PAM limits)." << std::endl;
   }
 }
 


### PR DESCRIPTION
## Summary
- clamp requested realtime priority to valid `SCHED_FIFO` bounds before calling `pthread_setschedparam`
- keep `priority=0` as an explicit no-op
- include `pthread_setschedparam` error code/text in warning logs for faster debugging

## Motivation
Realtime priority requests outside kernel bounds can fail silently or produce unclear warnings. This change makes behavior deterministic and diagnostics actionable.

## Testing
- validated in robot runtime where MPC callback thread reached `SCHED_FIFO` `rtprio=99`
- no dedicated CI run in this local step