### PR TITLE
#6 - Missing joy files added and ported to ros2

### DIFF
--- a/ocs2_robotic_examples/ocs2_legged_robot_ros/CMakeLists.txt
+++ b/ocs2_robotic_examples/ocs2_legged_robot_ros/CMakeLists.txt
@@ -34,6 +34,7 @@ find_package(Boost REQUIRED COMPONENTS system filesystem log_setup log)
 
 add_library(${PROJECT_NAME}
   src/gait/GaitKeyboardPublisher.cpp
+  src/gait/GaitJoypadPublisher.cpp
   src/gait/GaitReceiver.cpp
   src/visualization/LeggedRobotVisualizer.cpp
 )
@@ -108,6 +109,12 @@ add_executable(legged_robot_gait_command
 target_link_libraries(legged_robot_gait_command ${PROJECT_NAME})
 target_compile_options(legged_robot_gait_command PRIVATE ${OCS2_PINOCCHIO_FLAGS})
 
+add_executable(legged_robot_gait_joy_command
+  src/LeggedRobotGaitJoyCommandNode.cpp
+)
+target_link_libraries(legged_robot_gait_joy_command ${PROJECT_NAME})
+target_compile_options(legged_robot_gait_joy_command PRIVATE ${OCS2_PINOCCHIO_FLAGS})
+
 #############
 ## Install ##
 #############
@@ -125,6 +132,7 @@ install(TARGETS
   legged_robot_dummy
   legged_robot_target
   legged_robot_gait_command
+  legged_robot_gait_joy_command
   RUNTIME DESTINATION lib/${PROJECT_NAME}
 )
 install(DIRECTORY include/${PROJECT_NAME}/

--- a/ocs2_robotic_examples/ocs2_legged_robot_ros/include/ocs2_legged_robot_ros/gait/GaitJoypadPublisher.h
+++ b/ocs2_robotic_examples/ocs2_legged_robot_ros/include/ocs2_legged_robot_ros/gait/GaitJoypadPublisher.h
@@ -1,0 +1,65 @@
+/******************************************************************************
+Copyright (c) 2021, Farbod Farshidian. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ * Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+ * Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+ * Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************************************************************/
+
+#pragma once
+
+#include <map>
+#include <string>
+#include <vector>
+
+#include <ocs2_legged_robot/gait/ModeSequenceTemplate.h>
+
+#include <ocs2_msgs/msg/mode_schedule.hpp>
+#include <sensor_msgs/msg/joy.hpp>
+#include <std_msgs/msg/bool.hpp>
+
+#include "rclcpp/rclcpp.hpp"
+
+namespace ocs2 {
+namespace legged_robot {
+
+/** This class implements ModeSequence communication using ROS. */
+class GaitJoypadPublisher {
+ public:
+  GaitJoypadPublisher(const rclcpp::Node::SharedPtr& node,
+                      const std::string& gaitFile, const std::string& robotName,
+                      bool verbose = false);
+
+  void getJoyMsgCommand(const sensor_msgs::msg::Joy::ConstSharedPtr& joy);
+
+ private:
+  std::vector<std::string> gaitList_;
+  std::map<std::string, ModeSequenceTemplate> gaitMap_;
+
+  rclcpp::Publisher<ocs2_msgs::msg::ModeSchedule>::SharedPtr
+      modeSequenceTemplatePublisher_;
+};
+
+}  // namespace legged_robot
+}  // end of namespace ocs2

--- a/ocs2_robotic_examples/ocs2_legged_robot_ros/src/LeggedRobotGaitJoyCommandNode.cpp
+++ b/ocs2_robotic_examples/ocs2_legged_robot_ros/src/LeggedRobotGaitJoyCommandNode.cpp
@@ -1,0 +1,69 @@
+/******************************************************************************
+Copyright (c) 2021, Farbod Farshidian. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ * Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+ * Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+ * Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************************************************************/
+
+#include <sensor_msgs/msg/joy.hpp>
+
+#include <stdexcept>
+
+#include "ocs2_legged_robot_ros/gait/GaitJoypadPublisher.h"
+#include "rclcpp/rclcpp.hpp"
+
+using namespace ocs2;
+using namespace legged_robot;
+
+int main(int argc, char* argv[]) {
+  const std::string robotName = "legged_robot";
+
+  // Initialize ros node
+  rclcpp::init(argc, argv);
+  rclcpp::Node::SharedPtr node =
+      rclcpp::Node::make_shared(robotName + "_mpc_mode_schedule");
+
+  const std::string gaitCommandFile =
+      node->declare_parameter<std::string>("gaitCommandFile", "");
+  if (gaitCommandFile.empty()) {
+    throw std::runtime_error(
+        "[LeggedRobotGaitJoyCommandNode] Parameter 'gaitCommandFile' is "
+        "required.");
+  }
+  std::cerr << "Loading gait file: " << gaitCommandFile << std::endl;
+
+  GaitJoypadPublisher gaitCommand(node, gaitCommandFile, robotName, true);
+
+  auto joyModeSubscribe = node->create_subscription<sensor_msgs::msg::Joy>(
+      "/joy", 1,
+      std::bind(&GaitJoypadPublisher::getJoyMsgCommand, &gaitCommand,
+                std::placeholders::_1));
+
+  rclcpp::spin(node);
+  rclcpp::shutdown();
+
+  // Successful exit
+  return 0;
+}

--- a/ocs2_robotic_examples/ocs2_legged_robot_ros/src/gait/GaitJoypadPublisher.cpp
+++ b/ocs2_robotic_examples/ocs2_legged_robot_ros/src/gait/GaitJoypadPublisher.cpp
@@ -1,0 +1,94 @@
+/******************************************************************************
+Copyright (c) 2021, Farbod Farshidian. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ * Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+ * Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+ * Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************************************************************/
+
+#include "ocs2_legged_robot_ros/gait/GaitJoypadPublisher.h"
+
+#include <ocs2_core/misc/CommandLine.h>
+#include <ocs2_core/misc/LoadData.h>
+
+#include <algorithm>
+#include <ocs2_msgs/msg/mode_schedule.hpp>
+
+#include "ocs2_legged_robot_ros/gait/ModeSequenceTemplateRos.h"
+
+std::string gaitCommandPrev = "";
+namespace ocs2 {
+namespace legged_robot {
+
+/******************************************************************************************************/
+/******************************************************************************************************/
+/******************************************************************************************************/
+GaitJoypadPublisher::GaitJoypadPublisher(const rclcpp::Node::SharedPtr& node,
+                                         const std::string& gaitFile,
+                                         const std::string& robotName,
+                                         bool verbose) {
+  RCLCPP_INFO_STREAM(node->get_logger(),
+                     robotName + "_mpc_mode_schedule node is setting up ...");
+  loadData::loadStdVector(gaitFile, "list", gaitList_, verbose);
+
+  modeSequenceTemplatePublisher_ =
+      node->create_publisher<ocs2_msgs::msg::ModeSchedule>(
+          robotName + "_mpc_mode_schedule", 1);
+
+  gaitMap_.clear();
+  for (const auto& gaitName : gaitList_) {
+    gaitMap_.insert(
+        {gaitName, loadModeSequenceTemplate(gaitFile, gaitName, verbose)});
+  }
+  RCLCPP_INFO_STREAM(node->get_logger(),
+                     robotName + "_mpc_mode_schedule command node is ready.");
+}
+
+/******************************************************************************************************/
+/******************************************************************************************************/
+/******************************************************************************************************/
+void GaitJoypadPublisher::getJoyMsgCommand(
+    const sensor_msgs::msg::Joy::ConstSharedPtr& joy) {
+  std::string gaitCommand = "";
+  if (joy->buttons[3] == 1 || joy->buttons[2] == 1) {
+    if (joy->buttons[3] == 1) {
+      gaitCommand = "trot";
+    } else if (joy->buttons[2] == 1) {
+      gaitCommand = "stance";
+    }
+    if (gaitCommandPrev != gaitCommand) {
+      try {
+        ModeSequenceTemplate modeSequenceTemplate = gaitMap_.at(gaitCommand);
+        modeSequenceTemplatePublisher_->publish(
+            createModeSequenceTemplateMsg(modeSequenceTemplate));
+        gaitCommandPrev = gaitCommand;
+      } catch (const std::out_of_range& e) {
+        std::cout << "Gait \"" << gaitCommand << "\" not found.\n";
+      }
+    }
+  }
+}
+
+}  // namespace legged_robot
+}  // end of namespace ocs2


### PR DESCRIPTION
# Add joypad gait command node (ROS2 port)

Adds the joypad gait-command node to the ROS2 tree. These three files (`GaitJoypadPublisher.h/.cpp`, `LeggedRobotGaitJoyCommandNode.cpp`) already existed on `ros-one-devel` for ROS1 but were missing from this ROS2 branch; this commit ports them and wires them into the build. It's a near line-for-line `roscpp` → `rclcpp` translation, not a new design — same class, same gait-mapping logic, same publish-on-change behavior.

## Changes

- **`CMakeLists.txt`**

- **`include/ocs2_legged_robot_ros/gait/GaitJoypadPublisher.h`** *(new)*

- **`src/gait/GaitJoypadPublisher.cpp`** *(new)*

- **`src/LeggedRobotGaitJoyCommandNode.cpp`** *(new)*

## Tests
Tested on legged_control with emulated joypad
